### PR TITLE
Fix potential index out of range

### DIFF
--- a/stemmer_steps.go
+++ b/stemmer_steps.go
@@ -98,7 +98,7 @@ func step1C(input string) string {
 func step2(input string) string {
 	last := len(input) - 1
 
-	if last < 0 {
+	if last-1 < 0 {
 		return input
 	}
 
@@ -340,7 +340,7 @@ func step3(input string) string {
 func step4(input string) string {
 	last := len(input) - 1
 
-	if last < 0 {
+	if last-1 < 0 {
 		return input
 	}
 


### PR DESCRIPTION
A `last` value of 0 would previously result in a runtime exception.  Issue can be reproduced with:

`stemmer.Stem("IED")`